### PR TITLE
renaming multicloudhub-repo to multiclusterhub-repo in main and relea…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore binary
-multicloudhub-repo
+multiclusterhub-repo
 .DS_Store
 
 build-harness

--- a/cmd/repo/main.go
+++ b/cmd/repo/main.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/open-cluster-management/multicloudhub-repo/pkg/config"
-	"github.com/open-cluster-management/multicloudhub-repo/pkg/repo"
+	"github.com/open-cluster-management/multiclusterhub-repo/pkg/config"
+	"github.com/open-cluster-management/multiclusterhub-repo/pkg/repo"
 )
 
 func main() {

--- a/docs/Onboarding.md
+++ b/docs/Onboarding.md
@@ -53,7 +53,7 @@ A charts GitHub repository must be enabled with fast forwarding to release branc
 
 ### Contributing a Chart
 
-Before beginning to onboard your chart, please see our [contributing.md](https://github.com/open-cluster-management/multicloudhub-repo/blob/main/CONTRIBUTING.md). Follow the steps here for to ensure that the repo owners are aware of the desired change and can handle the desired change in a standard fashion. An issue must be created to ensure this can be tracked, as changes are also required in the MultiClusterHub Operator, to create an Application Subscription when installing the MCH.
+Before beginning to onboard your chart, please see our [contributing.md](https://github.com/open-cluster-management/multiclusterhub-repo/blob/main/CONTRIBUTING.md). Follow the steps here for to ensure that the repo owners are aware of the desired change and can handle the desired change in a standard fashion. An issue must be created to ensure this can be tracked, as changes are also required in the MultiClusterHub Operator, to create an Application Subscription when installing the MCH.
 
 ### Service Account
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-cluster-management/multicloudhub-repo
+module github.com/open-cluster-management/multiclusterhub-repo
 
 go 1.16
 

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package repo
 
 import (
@@ -11,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/open-cluster-management/multicloudhub-repo/pkg/config"
+	"github.com/open-cluster-management/multiclusterhub-repo/pkg/config"
 	"helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package repo
 
 import (
@@ -16,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-cluster-management/multicloudhub-repo/pkg/config"
+	"github.com/open-cluster-management/multiclusterhub-repo/pkg/config"
 	"helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/yaml"
 )
@@ -113,9 +112,9 @@ func Test_indexURL(t *testing.T) {
 				c: &config.Config{
 					Namespace: "test",
 					Port:      "8000",
-					Service:   "multicloudhub-repo",
+					Service:   "multiclusterhub-repo",
 				}},
-			want: "http://multicloudhub-repo.test.svc.cluster.local:8000/charts",
+			want: "http://multiclusterhub-repo.test.svc.cluster.local:8000/charts",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/repo/server.go
+++ b/pkg/repo/server.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 
-
 package repo
 
 import (
@@ -9,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/open-cluster-management/multicloudhub-repo/pkg/config"
+	"github.com/open-cluster-management/multiclusterhub-repo/pkg/config"
 )
 
 // Server holds an index.yaml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=open-cluster-management_multicloudhub-repo
-sonar.projectName=multicloudhub-repo
+sonar.projectKey=open-cluster-management_multiclusterhub-repo
+sonar.projectName=multiclusterhub-repo
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/vbh/**
 sonar.tests=.


### PR DESCRIPTION
…se-2.3 branches

this should finish up mch-repo rename in main and release-2.3

https://app.zenhub.com/workspaces/engineering-backlog-do-not-delete-604fab62d4b98d00150a2854/issues/open-cluster-management/backlog/10938